### PR TITLE
Fix action failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cytopia/phpcs:3
+FROM cytopia/phpcs:3-php7.4
 
 COPY entrypoint.sh \
      problem-matcher.json \


### PR DESCRIPTION
### Description of the Change
The action has [failed](https://github.com/10up/maps-block-apple/actions/runs/3428610047/jobs/5713119632) [multiple](https://github.com/10up/insecure-content-warning/actions/runs/3419054939/jobs/5692094502) times in the recent.

This PR locks the docker image to PHP 7.4 which should be compatible with WPCS release: https://github.com/WordPress/WordPress-Coding-Standards/issues/2035#issuecomment-1077737225

### How to test the Change
Tested on a temporary draft PR: https://github.com/10up/simple-podcasting/actions/runs/3428909916/jobs/5713819898
The test failures are correct (since it's not possible to use 10up-Default ruleset with wpcs-action yet)

The annotations work as expected: https://github.com/10up/simple-podcasting/pull/196/files

### Changelog Entry
> Fixed - Action failure with PHP8

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
