### PR TITLE
Add 10up-Default ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Available options (with default value):
             enable_warnings: false # Enable checking for warnings (-w)
             paths: '.' # Paths to check, space separated
             excludes: '' # Paths to excludes, space separated
-            standard: 'WordPress' # Standard to use. Accepts WordPress|WordPress-Core|WordPress-Docs|WordPress-Extra|WordPress-VIP-Go|WordPressVIPMinimum.
+            standard: 'WordPress' # Standard to use. Accepts WordPress|WordPress-Core|WordPress-Docs|WordPress-Extra|WordPress-VIP-Go|WordPressVIPMinimum|10up-Default.
             standard_repo: '' # Public (git) repository URL of the coding standard
             repo_branch: 'master' # Branch of Standard repository
             phpcs_bin_path: 'phpcs' # Custom PHPCS bin path

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,10 @@ if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "Word
     git clone https://github.com/Automattic/VIP-Coding-Standards ${HOME}/vipcs
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/vipcs,${HOME}/variable-analysis"
+elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
+    echo "Setting up 10up-Default"
+    git clone https://github.com/10up/phpcs-composer ${HOME}/10up
+    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up/10up-Default"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths ~/wpcs
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,10 @@ if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "Word
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     echo "Setting up 10up-Default"
     git clone https://github.com/10up/phpcs-composer ${HOME}/10up
-    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up"
+	git clone https://github.com/PHPCompatibility/PHPCompatibilityWP ${HOME}/phpcompatwp
+	git clone https://github.com/PHPCompatibility/PHPCompatibility ${HOME}/phpcompat
+	git clone https://github.com/PHPCompatibility/PHPCompatibilityParagonie ${HOME}/phpcompat-paragonie
+    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths ~/wpcs
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,10 +12,10 @@ if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "Word
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     echo "Setting up 10up-Default"
     git clone https://github.com/10up/phpcs-composer ${HOME}/10up
-	git clone https://github.com/PHPCompatibility/PHPCompatibilityWP ${HOME}/phpcompatwp
-	git clone https://github.com/PHPCompatibility/PHPCompatibility ${HOME}/phpcompat
-	git clone https://github.com/PHPCompatibility/PHPCompatibilityParagonie ${HOME}/phpcompat-paragonie
-	git clone https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils
+    git clone https://github.com/PHPCompatibility/PHPCompatibilityWP ${HOME}/phpcompatwp
+    git clone https://github.com/PHPCompatibility/PHPCompatibility ${HOME}/phpcompat
+    git clone https://github.com/PHPCompatibility/PHPCompatibilityParagonie ${HOME}/phpcompat-paragonie
+    git clone https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths ~/wpcs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,8 @@ if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "Word
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     echo "Setting up 10up-Default"
     git clone https://github.com/10up/phpcs-composer ${HOME}/10up
-    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up/10up-Default"
+	git clone https://github.com/PHPCompatibility/PHPCompatibilityWP ${HOME}/phpcompat
+    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompat/PHPCompatibilityWP"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths ~/wpcs
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,8 @@ elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
 	git clone https://github.com/PHPCompatibility/PHPCompatibilityWP ${HOME}/phpcompatwp
 	git clone https://github.com/PHPCompatibility/PHPCompatibility ${HOME}/phpcompat
 	git clone https://github.com/PHPCompatibility/PHPCompatibilityParagonie ${HOME}/phpcompat-paragonie
-    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat"
+	git clone https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils
+    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths ~/wpcs
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,7 @@ if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "Word
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     echo "Setting up 10up-Default"
     git clone https://github.com/10up/phpcs-composer ${HOME}/10up
-	git clone https://github.com/PHPCompatibility/PHPCompatibilityWP ${HOME}/phpcompat
-    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompat/PHPCompatibilityWP"
+    ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/10up"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths ~/wpcs
 else


### PR DESCRIPTION
### Description of the Change

This PR adds support for 10up-Default ruleset.

Usage:

```
    steps:
      - uses: actions/checkout@v2
      - name: WPCS check
        uses: 10up/wpcs-action@stable
        with:
          use_local_config: true
          standard: '10up-Default'
```

Note: if local config include 10up-Default rule, we should specify the standard argument in the step configuration. It is required to correctly set up standards while performing the step.

Closes #9 

### How to test the Change

Tested on Simple Podcasting: https://github.com/10up/simple-podcasting/pull/196/files

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Support of 10up-Default ruleset

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
