### PR TITLE
Change from using `master` branch to the 2.3.0 tag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 cp /action/problem-matcher.json /github/workflow/problem-matcher.json
 
-git clone -b master https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs
+git clone -b main https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs
 
 if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "WordPressVIPMinimum" ]; then
     echo "Setting up VIPCS"
@@ -48,7 +48,7 @@ fi
 # .phpcs.xml, phpcs.xml, .phpcs.xml.dist, phpcs.xml.dist
 if [ -f ".phpcs.xml" ] || [ -f "phpcs.xml" ] || [ -f ".phpcs.xml.dist" ] || [ -f "phpcs.xml.dist" ]; then
     HAS_CONFIG=true
-else 
+else
     HAS_CONFIG=false
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 cp /action/problem-matcher.json /github/workflow/problem-matcher.json
 
-git clone -b main https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs
+git clone --depth 1 -b 2.3.0 https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs
 
 if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "WordPressVIPMinimum" ]; then
     echo "Setting up VIPCS"


### PR DESCRIPTION
### Description of the Change

The WordPress Coding Standards repo has removed the use of the `master` branch and have gone with `main` branch instead. This repo has a call to clone the `master` branch, which is currently failing. This PR fixes that by switching to use the latest tagged release, 2.3.0.

Once version 3.0.0 of WPCS is released, we should test that version with this tool to ensure everything works. If so, we should either switch to that tag or switch to using the `main` branch (which allows us to ensure the latest version is always pulled in).

Closes #33 

### How to test the Change

Locally, run the following line to see the error:

`git clone -b master https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs`

Then run the new line to ensure it works:

`git clone --depth 1 -b 2.3.0 https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs`

### Changelog Entry

> Fixed - Clone the 2.3.0 tagged branch of the WordPress Coding Standards

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
