### PR TITLE
Install the VIPCS package from a specific branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ git clone --depth 1 -b 2.3.0 https://github.com/WordPress/WordPress-Coding-Stand
 
 if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "WordPressVIPMinimum" ]; then
     echo "Setting up VIPCS"
-    git clone https://github.com/Automattic/VIP-Coding-Standards ${HOME}/vipcs
+    git clone --depth 1 -b 2.3.3 https://github.com/Automattic/VIP-Coding-Standards.git ${HOME}/vipcs
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${HOME}/wpcs,${HOME}/vipcs,${HOME}/variable-analysis"
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then


### PR DESCRIPTION
### Description of the Change

We currently install the VIPCS package from the main branch, which means we're always pulling in the latest changes. They recently made some major changes to go along with the 3.0.0 release of the WPCS package and this breaks things with how we currently install these packages.

Similar to the change in #34, this PR fixes things by installing a specific branch of the VIPCS package. This allows things to run properly again, though same as noted in #34, we should look to refactor how we install these packages to use composer instead, to ensure we can use the latest versions of things (so this fix should be looked at as temporary).

### How to test the Change

Can see that with this change in place, issues are properly flagged in [ClassifAI](https://github.com/10up/classifai/actions/runs/6027481847/job/16352770187?pr=572)

### Changelog Entry

> Fixed - Clone the 2.3.3 tagged release of the VIPCS package to ensure running VIP scans works.

### Credits

Props @dkotter, @TylerB24890 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
