### PR TITLE
Install the WordPress codings standards from the proper directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,7 +118,7 @@ elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
 
     decide_all_files_or_changed "${HOME}/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,${HOME}/vipcs,${HOME}/variable-analysis"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
-  decide_all_files_or_changed "~/wpcs"
+  decide_all_files_or_changed "${HOME}/wpcs"
 else
   echo "Standard repository: ${INPUT_STANDARD_REPO}"
   git clone -b ${INPUT_REPO_BRANCH} ${INPUT_STANDARD_REPO} ${HOME}/cs


### PR DESCRIPTION
### Description of the Change
Use the installed WordPress coding standards from the proper directory.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #4

### How to test the Change
Create a repo that uses the action and has PHPCS errors and warnings and the `WordPress` standards just like this one https://github.com/kmgalanakis/wpcs-action/pull/1

### Changelog Entry
> Fixed - Using "WordPress" standards


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
