### PR TITLE
Fix #35 | Upgrade WordPress Coding Standards to 3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN chmod +x /action/entrypoint.sh
 
 RUN apk update && \
     apk upgrade && \
-    apk add git
+    apk add git && \
+    apk add composer
 
 ENTRYPOINT ["/action/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN chmod +x /action/entrypoint.sh
 
 RUN apk update && \
     apk upgrade && \
-    apk add git composer php8-simplexml php8-tokenizer
+    apk add git composer php8-simplexml php8-tokenizer php8-xmlreader php8-xmlwriter
 
 ENTRYPOINT ["/action/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN chmod +x /action/entrypoint.sh
 
 RUN apk update && \
     apk upgrade && \
-    apk add git && \
-    apk add composer
+    apk add git composer php8-simplexml php8-tokenizer
 
 ENTRYPOINT ["/action/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,37 @@
-FROM cytopia/phpcs:3-php7.4
+FROM php:8.0-cli-alpine
+
+# Install build dependencies
+RUN set -eux \
+	&& apk add --no-cache \
+		ca-certificates \
+		coreutils \
+		curl \
+		git \
+		php8-simplexml \
+		php8-tokenizer \
+		php8-xmlreader \
+		php8-xmlwriter \
+		php-xml \
+	&& git clone https://github.com/PHPCSStandards/PHP_CodeSniffer
+
+# Install PHP CodeSniffer
+RUN set -eux \
+	&& cd PHP_CodeSniffer \
+	&& VERSION="$( git describe --abbrev=0 --tags )" \
+	&& curl -sS -L https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/download/${VERSION}/phpcs.phar -o /phpcs.phar \
+	&& chmod +x /phpcs.phar \
+	&& mv /phpcs.phar /usr/bin/phpcs \
+	&& phpcs --version
+
+# Install PHP Composer
+RUN set -eux \
+	&& curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
+	&& composer --version
 
 COPY entrypoint.sh \
      problem-matcher.json \
      /action/
 
 RUN chmod +x /action/entrypoint.sh
-
-RUN apk update && \
-    apk upgrade && \
-    apk add git composer php8-simplexml php8-tokenizer php8-xmlreader php8-xmlwriter
 
 ENTRYPOINT ["/action/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 cp /action/problem-matcher.json /github/workflow/problem-matcher.json
 
-git clone --depth 1 -b 2.3.0 https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs
+git clone --depth 1 -b 3.1.0 https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs
 
 git config --global --add safe.directory $(pwd)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,7 +113,7 @@ if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "Word
     git clone --depth 1 -b 2.3.3 https://github.com/Automattic/VIP-Coding-Standards.git ${HOME}/vipcs
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
-    decide_all_files_or_changed "${HOME}/vipcs,${HOME}/variable-analysis"
+    decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/vipcs,${HOME}/variable-analysis"
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     echo "Setting up 10up-Default"
     git clone https://github.com/10up/phpcs-composer ${HOME}/10up

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,13 @@
 
 cp /action/problem-matcher.json /github/workflow/problem-matcher.json
 
+# Install Composer if not found
+if ! [ -x "$(command -v composer)" ]; then
+  echo 'Composer not found, installing...'
+  curl -sS https://getcomposer.org/installer | php
+  mv composer.phar /usr/local/bin/composer
+fi
+
 composer global require "dealerdirect/phpcodesniffer-composer-installer:^0.7.1" "wp-coding-standards/wpcs:^3.1.0"
 
 git config --global --add safe.directory $(pwd)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 cp /action/problem-matcher.json /github/workflow/problem-matcher.json
 
-git clone --depth 1 -b 3.1.0 https://github.com/WordPress/WordPress-Coding-Standards.git ~/wpcs
+composer global require "dealerdirect/phpcodesniffer-composer-installer:^0.7.1" "wp-coding-standards/wpcs:^3.1.0"
 
 git config --global --add safe.directory $(pwd)
 
@@ -105,7 +105,7 @@ if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "Word
     git clone --depth 1 -b 2.3.3 https://github.com/Automattic/VIP-Coding-Standards.git ${HOME}/vipcs
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
-    decide_all_files_or_changed "${HOME}/wpcs,${HOME}/vipcs,${HOME}/variable-analysis"
+    decide_all_files_or_changed "${HOME}/vipcs,${HOME}/variable-analysis"
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     echo "Setting up 10up-Default"
     git clone https://github.com/10up/phpcs-composer ${HOME}/10up
@@ -116,14 +116,14 @@ elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     git clone https://github.com/Automattic/VIP-Coding-Standards ${HOME}/vipcs
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
-    decide_all_files_or_changed "${HOME}/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,${HOME}/vipcs,${HOME}/variable-analysis"
+    decide_all_files_or_changed "${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,${HOME}/vipcs,${HOME}/variable-analysis"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
-  decide_all_files_or_changed "${HOME}/wpcs"
+  decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs"
 else
   echo "Standard repository: ${INPUT_STANDARD_REPO}"
   git clone -b ${INPUT_REPO_BRANCH} ${INPUT_STANDARD_REPO} ${HOME}/cs
 
-  decide_all_files_or_changed "${HOME}/wpcs,${HOME}/cs"
+  decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/cs"
 fi
 
 if [ -z "${INPUT_EXCLUDES}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -126,7 +126,9 @@ elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
 
     decide_all_files_or_changed "${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,${HOME}/vipcs,${HOME}/variable-analysis"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
-  decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs"
+  echo "Setting up default WPCS"
+  git clone --depth 1 --branch 1.0.11 https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils
+  decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/phpcsutils/PHPCSUtils"
 else
   echo "Standard repository: ${INPUT_STANDARD_REPO}"
   git clone -b ${INPUT_REPO_BRANCH} ${INPUT_STANDARD_REPO} ${HOME}/cs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,7 +124,7 @@ elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     git clone https://github.com/Automattic/VIP-Coding-Standards ${HOME}/vipcs
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
-    decide_all_files_or_changed "${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,${HOME}/vipcs,${HOME}/variable-analysis"
+    decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,${HOME}/vipcs,${HOME}/variable-analysis"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
   echo "Setting up default WPCS"
   git clone --depth 1 --branch 1.0.11 https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,7 +114,7 @@ if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "Word
     git clone --depth 1 -b 2.3.3 https://github.com/Automattic/VIP-Coding-Standards.git ${HOME}/vipcs
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
-    decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/vipcs,${HOME}/variable-analysis"
+    decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/vipcs,${HOME}/variable-analysis,${HOME}/phpcsutils/PHPCSUtils"
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     echo "Setting up 10up-Default"
     git clone https://github.com/10up/phpcs-composer ${HOME}/10up
@@ -126,10 +126,14 @@ elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
     decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,$(composer config home)/vendor/phpcsstandards/phpcsextra,${HOME}/vipcs,${HOME}/variable-analysis"
+
+    # Add the phpcs -i command to list installed standards
+    echo "Installed coding standards:"
+    phpcs -i
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
   echo "Setting up default WPCS"
   git clone --depth 1 --branch 1.0.11 https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils
-  decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/phpcsutils/PHPCSUtils"
+  decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/phpcsutils/PHPCSUtils,$(composer config home)/vendor/phpcsstandards/phpcsextra"
 else
   echo "Standard repository: ${INPUT_STANDARD_REPO}"
   git clone -b ${INPUT_REPO_BRANCH} ${INPUT_STANDARD_REPO} ${HOME}/cs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,8 @@ if ! [ -x "$(command -v composer)" ]; then
   mv composer.phar /usr/local/bin/composer
 fi
 
-composer global require "dealerdirect/phpcodesniffer-composer-installer:^0.7.1" "wp-coding-standards/wpcs:^3.1.0"
+composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+composer global require --dev wp-coding-standards/wpcs:"^3.0.0" --update-with-dependencies
 
 git config --global --add safe.directory $(pwd)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ if ! [ -x "$(command -v composer)" ]; then
 fi
 
 composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+composer global require --dev phpcsstandards/phpcsextra:"^1.2.0"
 composer global require --dev wp-coding-standards/wpcs:"^3.0.0" --update-with-dependencies
 
 git config --global --add safe.directory $(pwd)
@@ -124,7 +125,7 @@ elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     git clone https://github.com/Automattic/VIP-Coding-Standards ${HOME}/vipcs
     git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
-    decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,${HOME}/vipcs,${HOME}/variable-analysis"
+    decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,$(composer config home)/vendor/phpcsstandards/phpcsextra,${HOME}/vipcs,${HOME}/variable-analysis"
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
   echo "Setting up default WPCS"
   git clone --depth 1 --branch 1.0.11 https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,18 +2,11 @@
 
 cp /action/problem-matcher.json /github/workflow/problem-matcher.json
 
-# Install Composer if not found
-if ! [ -x "$(command -v composer)" ]; then
-  echo 'Composer not found, installing...'
-  curl -sS https://getcomposer.org/installer | php
-  mv composer.phar /usr/local/bin/composer
-fi
+git config --global --add safe.directory $(pwd)
 
 composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-composer global require --dev phpcsstandards/phpcsextra:"^1.2.0"
-composer global require --dev wp-coding-standards/wpcs:"^3.0.0" --update-with-dependencies
-
-git config --global --add safe.directory $(pwd)
+composer global require --dev wp-coding-standards/wpcs:"^3.1.0" --update-with-dependencies
+composer global require --dev 10up/phpcs-composer:"^3.0"
 
 diff_lines() {
   path=""
@@ -109,36 +102,29 @@ else
     echo "Will check all files"
 fi
 
+COMPOSER_HOME="$(composer config home)/vendor"
+WPCS_PATH="$(composer config home)/vendor/wp-coding-standards/wpcs,$(composer config home)/vendor/phpcsstandards/phpcsutils,$(composer config home)/vendor/phpcsstandards/phpcsextra"
 if [ "${INPUT_STANDARD}" = "WordPress-VIP-Go" ] || [ "${INPUT_STANDARD}" = "WordPressVIPMinimum" ]; then
     echo "Setting up VIPCS"
-    git clone --depth 1 -b 2.3.3 https://github.com/Automattic/VIP-Coding-Standards.git ${HOME}/vipcs
-    git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
-    decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/vipcs,${HOME}/variable-analysis,${HOME}/phpcsutils/PHPCSUtils"
+    decide_all_files_or_changed "${WPCS_PATH},${COMPOSER_HOME}/automattic/vipwpcs,${COMPOSER_HOME}/sirbrillig/phpcs-variable-analysis"
 elif [ "${INPUT_STANDARD}" = "10up-Default" ]; then
     echo "Setting up 10up-Default"
-    git clone https://github.com/10up/phpcs-composer ${HOME}/10up
-    git clone https://github.com/PHPCompatibility/PHPCompatibilityWP ${HOME}/phpcompatwp
-    git clone https://github.com/PHPCompatibility/PHPCompatibility ${HOME}/phpcompat
-    git clone https://github.com/PHPCompatibility/PHPCompatibilityParagonie ${HOME}/phpcompat-paragonie
-    git clone --depth 1 --branch 1.0.11 https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils
-    git clone https://github.com/Automattic/VIP-Coding-Standards ${HOME}/vipcs
-    git clone https://github.com/sirbrillig/phpcs-variable-analysis ${HOME}/variable-analysis
 
-    decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/10up/10up-Default,${HOME}/phpcompatwp/PHPCompatibilityWP,${HOME}/phpcompat/PHPCompatibility,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieSodiumCompat,${HOME}/phpcompat-paragonie/PHPCompatibilityParagonieRandomCompat,${HOME}/phpcsutils/PHPCSUtils,$(composer config home)/vendor/phpcsstandards/phpcsextra,${HOME}/vipcs,${HOME}/variable-analysis"
+    decide_all_files_or_changed "${WPCS_PATH},${COMPOSER_HOME}/10up/phpcs-composer,${COMPOSER_HOME}/phpcompatibility/phpcompatibility-wp,${COMPOSER_HOME}/phpcompatibility/php-compatibility,${COMPOSER_HOME}/phpcompatibility/phpcompatibility-paragonie,${COMPOSER_HOME}/automattic/vipwpcs,${COMPOSER_HOME}/sirbrillig/phpcs-variable-analysis"
 
     # Add the phpcs -i command to list installed standards
     echo "Installed coding standards:"
     phpcs -i
 elif [ -z "${INPUT_STANDARD_REPO}" ] || [ "${INPUT_STANDARD_REPO}" = "false" ]; then
   echo "Setting up default WPCS"
-  git clone --depth 1 --branch 1.0.11 https://github.com/PHPCSStandards/PHPCSUtils ${HOME}/phpcsutils
-  decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/phpcsutils/PHPCSUtils,$(composer config home)/vendor/phpcsstandards/phpcsextra"
+
+  decide_all_files_or_changed "${WPCS_PATH}"
 else
   echo "Standard repository: ${INPUT_STANDARD_REPO}"
   git clone -b ${INPUT_REPO_BRANCH} ${INPUT_STANDARD_REPO} ${HOME}/cs
 
-  decide_all_files_or_changed "$(composer config home)/vendor/wp-coding-standards/wpcs,${HOME}/cs"
+  decide_all_files_or_changed "${WPCS_PATH},${HOME}/cs"
 fi
 
 if [ -z "${INPUT_EXCLUDES}" ]; then


### PR DESCRIPTION
### Description of the Change
PR upgrades WordPress Coding Standards to 3.1.0.

Additionally, this PR make changes in docker file as well to allow update phpcs to latest version. (Previous docker image is installing phpcs from https://github.com/squizlabs/PHP_CodeSniffer which at 3.7.2)

Closes https://github.com/10up/wpcs-action/issues/35

### How to test the Change
Test action pointed to this PR branch on any repo and make sure it works fine and report errors/warning correctly. Make sure you tests all different options this action provides. 

**Example**: I have tried testing different combination with following workflow file it seems working fine:
```
name: WPCS check

on: pull_request

jobs:
  phpcs:
      name: Default CS
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
        - uses: 10up/wpcs-action@fix/35-upgrade-wordpress-coding-standards-to-3.1
  vipcs:
      name: VIPCS
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
        - uses: 10up/wpcs-action@fix/35-upgrade-wordpress-coding-standards-to-3.1
          with:
            standard: 'WordPress-VIP-Go'
  tenupcs:
      name: 10upCS
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
        - uses: 10up/wpcs-action@fix/35-upgrade-wordpress-coding-standards-to-3.1
          with:
            standard: 10up-Default
            enable_warnings: true
            excludes: './tests/'
  localconfig: 
      name: Use Local Config
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
        - uses: 10up/wpcs-action@fix/35-upgrade-wordpress-coding-standards-to-3.1
          with:
            use_local_config: 'true'
            extra_args: "--extensions=php"
  changed_files:
      name: Changed Files only
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
          with:
            fetch-depth: 0
        - uses: 10up/wpcs-action@fix/35-upgrade-wordpress-coding-standards-to-3.1
          with:
            standard: 10up-Default
            only_changed_files: 'true'
  custom_standard:
      name: Custom standard repo
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
        - uses: 10up/wpcs-action@fix/35-upgrade-wordpress-coding-standards-to-3.1
          with:
            standard_repo: 'https://github.com/10up/phpcs-composer'
            repo_branch: 'trunk'
  excludes:
      name: With excludes
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
        - uses: 10up/wpcs-action@fix/35-upgrade-wordpress-coding-standards-to-3.1
          with:
            standard: 10up-Default
            excludes: './tests/,./includes/admin/post-meta.php'
  includes:
      name: With paths only
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
        - uses: 10up/wpcs-action@fix/35-upgrade-wordpress-coding-standards-to-3.1
          with:
            standard: 10up-Default
            paths: './includes/admin/post-meta.php ./includes/admin/settings.php'
```


### Changelog Entry
> Changed - Upgrade WordPress Coding Standards to 3.1.0


### Credits
Props @sksaju, @mehul0810 @benlk @thrijith @s3rgiosan @jeffpaul @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
