### PR TITLE
fix: download version 3.x of PHPCS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux \
 		php8-xmlreader \
 		php8-xmlwriter \
 		php-xml \
-	&& git clone https://github.com/PHPCSStandards/PHP_CodeSniffer
+	&& git clone -b 3.x https://github.com/PHPCSStandards/PHP_CodeSniffer
 
 # Install PHP CodeSniffer
 RUN set -eux \


### PR DESCRIPTION
### Description of the Change
Use the 3.x branch of PHP CodeSniffer. This is needed until the coding standards are updated to work with CodeSniffer 4.x

A better longer-term fix is to install PHPCS using `composer` instead of relying on git clone.

Closes #52.

### How to test the Change
Run the action.

### Changelog Entry
> Fixed - Use version 3.x of PHP CodeSniffer.

### Credits
Props @paulschreiber

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
